### PR TITLE
Refreshes stale users after refresh date

### DIFF
--- a/actions/error_actions.js
+++ b/actions/error_actions.js
@@ -125,3 +125,10 @@ export const userDeleteFailure = (error: string) => {
     error
   };
 }
+
+export const userRefreshFailure = (error: string) => {
+  return {
+    type: 'REFRESH_USER_ERROR',
+    error
+  };
+}

--- a/actions/initialize_actions.js
+++ b/actions/initialize_actions.js
@@ -1,5 +1,6 @@
 import { dispatch } from 'react';
 import { AsyncStorage } from 'react-native';
+import { refreshUser } from './user_actions';
 
 function initializeAppSuccess() {
   return {
@@ -14,6 +15,10 @@ function loadSavedSessionData(sessionData) {
   };
 }
 
+function usersNeedsRefresh(user) {
+  return Date.parse(user.refresh_at) < Date.now();
+}
+
 export const initializeHomeScreen = () => {
   return dispatch => {
     AsyncStorage.getItem('sessionData').then((sessionData) => {
@@ -21,6 +26,10 @@ export const initializeHomeScreen = () => {
         sessionData = JSON.parse(sessionData);
         if (sessionData.user && sessionData.session) {
           dispatch(loadSavedSessionData(sessionData));
+
+          if (usersNeedsRefresh(sessionData.user)) {
+            dispatch(refreshUser(sessionData.user));
+          }
         }
       }
 

--- a/actions/user_actions.js
+++ b/actions/user_actions.js
@@ -168,7 +168,6 @@ function userDeleteSuccess(user) {
   }
 }
 
-
 export const deleteUser = (user) => {
   let url = `${baseUrl}/auth`;
 
@@ -181,5 +180,33 @@ export const deleteUser = (user) => {
       .then(parseResponse(200, 'There was an error deleting. Please try again.'))
       .then(_json => dispatch(userDeleteSuccess(user)))
       .catch(error => dispatch(userDeleteFailure(error)))
+  }
+}
+
+function startRefreshingUser() {
+  return {
+    type: 'START_REFRESHING_USER'
+  };
+}
+
+function userRefreshSuccess(user) {
+  updateSavedUser(user);
+  return {
+    type: 'USER_REFRESH_SUCCESS',
+    user: user
+  };
+}
+
+export const refreshUser = (oldUser) => {
+  let url = `${baseUrl}/users/${oldUser.id}`
+
+  return dispatch => {
+    const { session } = dispatch(startRefreshingUser());
+    return fetch(url, applyAuthenticationHeaders({
+      method: 'GET'
+    }, session))
+      .then(parseResponse(200, 'There was an error refreshing user. Please try again.'))
+      .then(json => dispatch(userRefreshSuccess(json)))
+      .catch(error => dispatch(userRefreshFailure(error)))
   }
 }

--- a/reducers/user_reducer.js
+++ b/reducers/user_reducer.js
@@ -158,6 +158,11 @@ const user = (state = initialUserState, action) => {
         isDeletingUser: false,
         errorMessage: action.error
       };
+    case 'USER_REFRESH_SUCCESS':
+      return {
+        ...state,
+        user: action.user
+      };
     default:
       return state;
   }


### PR DESCRIPTION
Why
---
AWS allows access to private images for up to 1 week. Since the user is
cached for longer than that, at some point their profile image will no
longer be accessible.

This change addresses the need by
---------------------------------
Looks at a new refresh_at attribute on the user and retrieves updated
user if refresh at is earlier than current time